### PR TITLE
Show only the project name on the OLED header

### DIFF
--- a/v1/lib/peripherals/oled_ssd1306.cpp
+++ b/v1/lib/peripherals/oled_ssd1306.cpp
@@ -8,9 +8,7 @@ unsigned int OledSsd1306::getWidth() { return this->width; }
 
 unsigned int OledSsd1306::getHeight() { return this->height; }
 
-String OledSsd1306::getHeader() {
-  return String(this->projectName) + " " + String(this->deviceId);
-}
+String OledSsd1306::getHeader() { return String(this->projectName); }
 
 String OledSsd1306::floatToString_6(float num) {
   String result;
@@ -29,10 +27,8 @@ String OledSsd1306::floatToString_6(float num) {
 }
 
 OledSsd1306::OledSsd1306(unsigned int width, unsigned int height,
-                         unsigned int address, const char *projectName,
-                         const char *deviceId)
-    : width(width), height(height), projectName(projectName),
-      deviceId(deviceId) {
+                         unsigned int address, const char *projectName)
+    : width(width), height(height), projectName(projectName) {
   this->display = new Adafruit_SSD1306(width, height, &Wire, -1);
 }
 

--- a/v1/lib/peripherals/oled_ssd1306.h
+++ b/v1/lib/peripherals/oled_ssd1306.h
@@ -21,7 +21,6 @@ private:
   unsigned int height; // The height of the display.
 
   const char *projectName; // The project name.
-  const char *deviceId;    // The device ID.
 
   /**
     Get the display object.
@@ -51,7 +50,7 @@ private:
     Get the header.
 
     Returns:
-      The header, which is the project name and the device ID.
+      The header, which is the project name.
    */
   String getHeader();
 
@@ -77,10 +76,9 @@ public:
       height - The height of the display.
       address - The address of the display.
       projectName - The project name.
-      deviceId - The device ID.
    */
   OledSsd1306(unsigned int width, unsigned int height, unsigned int address,
-              const char *projectName, const char *deviceId);
+              const char *projectName);
 
   /**
     Destructor.

--- a/v1/src/main.cpp
+++ b/v1/src/main.cpp
@@ -483,8 +483,7 @@ void setup() {
 
   // Initialize the OLED SSD1306 display
   oled = new peripherals::OledSsd1306(OLED_SSD1306_WIDTH, OLED_SSD1306_HEIGHT,
-                                      OLED_SSD1306_ADDRESS, PROJECT_NAME,
-                                      DEVICE_ID);
+                                      OLED_SSD1306_ADDRESS, PROJECT_NAME);
   bool ok = oled->Begin(OLED_SSD1306_ADDRESS);
   if (!ok)
     logger->Error("SETUP", "Failed to initialize the OLED SSD1306 display");


### PR DESCRIPTION
## Summary

The OLED display header showed the project name **and** the device id. This change makes the first section show only the project name (`oasis`).

## Changes

- `getHeader()` now returns just the project name
- Remove the now-unused `deviceId` field and constructor parameter from the OLED display class
- Update the call site in `main.cpp` accordingly

## Note

The device id is still used as the MQTT client id and in the topic schema (`/oasis/<device-id>/v1/...`); it is only removed from the screen.

## Validation

- `pio run` builds successfully.